### PR TITLE
Feature/remove kleisli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,11 @@ jobs:
         run: dotnet test -c Release
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
-        run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$GITHUB_RUN_ID src/$PROJECT_NAME/$PROJECT_NAME.*proj
+        run: |
+          latestTag=$(git describe --tags --abbrev=0 2>/dev/null || echo 0.0.1)
+          runId=$GITHUB_RUN_ID
+          packageVersion="${latestTag//v}-build.${runId}"
+          dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$packageVersion src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Upload Artifact
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v2

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -3357,9 +3357,11 @@ Unlike Giraffe's default router (which really is just a big `HttpHandler` functi
 ```fsharp
 let endpoints =
     [
-        GET => route "/" (text "Hello World")
-        GET => routef "/%s/%i" handler2
-        GET => routef "/%s/%s/%s/%i" handler3
+        GET [
+            route "/" (text "Hello World")
+            routef "/%s/%i" handler2
+            routef "/%s/%s/%s/%i" handler3
+        ]
         subRoute "/sub" [
             // Not specifying a http verb means it will listen to all verbs
             route "/test" handler1

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -107,9 +107,9 @@ There is no limit to how many `HttpHandler` functions can be chained with `compo
 ```fsharp
 let app =
     route "/"
-    >=> setHttpHeader "X-Foo" "Bar"
-    >=> setStatusCode 200
-    >=> setBodyFromString "Hello World"
+    >> setHttpHeader "X-Foo" "Bar"
+    >> setStatusCode 200
+    >> setBodyFromString "Hello World"
 ```
 
 If you would like to learn more about the `>=>` (fish) operator then please check out [Scott Wlaschin's blog post on Railway oriented programming](http://fsharpforfunandprofit.com/posts/recipe-part2/).
@@ -121,8 +121,8 @@ The `choose` combinator function iterates through a list of `HttpHandler` functi
 ```fsharp
 let app =
     choose [
-        route "/foo" >=> text "Foo"
-        route "/bar" >=> text "Bar"
+        route "/foo" >> text "Foo"
+        route "/bar" >> text "Bar"
     ]
 ```
 
@@ -144,8 +144,8 @@ let time() = System.DateTime.Now.ToString()
 
 let webApp =
     choose [
-        route "/normal"  >=> text (time())
-        route "/warbler" >=> warbler (fun _ -> text (time()))
+        route "/normal"  >> text (time())
+        route "/warbler" >> warbler (fun _ -> text (time()))
     ]
 ```
 
@@ -380,8 +380,8 @@ open Giraffe
 
 let webApp =
     choose [
-        route "/ping"   >=> text "pong"
-        route "/"       >=> htmlFile "/pages/index.html" ]
+        route "/ping"   >> text "pong"
+        route "/"       >> htmlFile "/pages/index.html" ]
 
 type Startup() =
     member __.ConfigureServices (services : IServiceCollection) =
@@ -414,8 +414,8 @@ open Giraffe
 
 let webApp =
     choose [
-        route "/ping"   >=> text "pong"
-        route "/"       >=> htmlFile "/pages/index.html" ]
+        route "/ping"   >> text "pong"
+        route "/"       >> htmlFile "/pages/index.html" ]
 
 let configureApp (app : IApplicationBuilder) =
     // Add Giraffe to the ASP.NET Core pipeline
@@ -730,8 +730,8 @@ let notFoundHandler : HttpHandler =
 
 let webApp =
     choose [
-        route "/foo" >=> text "Foo"
-        route "/bar" >=> text "Bar"
+        route "/foo" >> text "Foo"
+        route "/bar" >> text "Bar"
         notFoundHandler
     ]
 ```

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -106,10 +106,10 @@ There is no limit to how many `HttpHandler` functions can be chained with `compo
 
 ```fsharp
 let app =
-    route "/"
-    >> setHttpHeader "X-Foo" "Bar"
-    >> setStatusCode 200
-    >> setBodyFromString "Hello World"
+    ROUTE "/"
+    |> setHttpHeader "X-Foo" "Bar"
+    |> setStatusCode 200
+    |> setBodyFromString "Hello World"
 ```
 
 If you would like to learn more about the `>=>` (fish) operator then please check out [Scott Wlaschin's blog post on Railway oriented programming](http://fsharpforfunandprofit.com/posts/recipe-part2/).
@@ -120,9 +120,9 @@ The `choose` combinator function iterates through a list of `HttpHandler` functi
 
 ```fsharp
 let app =
-    choose [
-        route "/foo" >> text "Foo"
-        route "/bar" >> text "Bar"
+    CHOOSE [
+        ROUTE "/foo" >> text "Foo"
+        ROUTE "/bar" >> text "Bar"
     ]
 ```
 
@@ -143,9 +143,9 @@ A warbler will ensure that a function will get evaluated every time the route is
 let time() = System.DateTime.Now.ToString()
 
 let webApp =
-    choose [
-        route "/normal"  >> text (time())
-        route "/warbler" >> warbler (fun _ -> text (time()))
+    CHOOSE [
+        ROUTE "/normal"  >> text (time())
+        ROUTE "/warbler" >> warbler (fun _ -> text (time()))
     ]
 ```
 
@@ -379,9 +379,9 @@ Create a web application and plug it into the ASP.NET Core middleware:
 open Giraffe
 
 let webApp =
-    choose [
-        route "/ping"   >> text "pong"
-        route "/"       >> htmlFile "/pages/index.html" ]
+    CHOOSE [
+        ROUTE "/ping"   |> text "pong"
+        ROUTE "/"       |> htmlFile "/pages/index.html" ]
 
 type Startup() =
     member __.ConfigureServices (services : IServiceCollection) =
@@ -413,9 +413,9 @@ Instead of creating a `Startup` class you can also add Giraffe in a more functio
 open Giraffe
 
 let webApp =
-    choose [
-        route "/ping"   >> text "pong"
-        route "/"       >> htmlFile "/pages/index.html" ]
+    CHOOSE [
+        ROUTE "/ping"   |> text "pong"
+        ROUTE "/"       |> htmlFile "/pages/index.html" ]
 
 let configureApp (app : IApplicationBuilder) =
     // Add Giraffe to the ASP.NET Core pipeline
@@ -729,9 +729,9 @@ let notFoundHandler : HttpHandler =
     >=> RequestErrors.NOT_FOUND "Not Found"
 
 let webApp =
-    choose [
-        route "/foo" >> text "Foo"
-        route "/bar" >> text "Bar"
+    CHOOSE [
+        ROUTE "/foo" >> text "Foo"
+        ROUTE "/bar" >> text "Bar"
         notFoundHandler
     ]
 ```
@@ -764,7 +764,7 @@ let submitBarHandler : HttpHandler =
     // Do something
 
 let webApp =
-    choose [
+    CHOOSE [
         // Filters for GET requests
         GET  >=> choose [
             route "/foo" >=> text "Foo"
@@ -815,8 +815,8 @@ let someHttpHandler : HttpHandler =
 // or...
 
 let someHttpHandler : HttpHandler =
-    setStatusCode 200
-    >=> text "Hello World"
+    SET_STATUS_CODE 200
+    |> text "Hello World"
 ```
 
 Giraffe also offers a default set of pre-defined `HttpHandler` functions, which can be used to return a response with a specific HTTP status code.
@@ -859,9 +859,9 @@ let johnDoe =
         LastName  = "Doe"
     }
 
-let app = choose [
-    route `/`     >=> Successful.OK "Hello World"
-    route `/john` >=> Successful.OK johnDoe
+let app = CHOOSE [
+    ROUTE `/`     |> Successful.OK "Hello World"
+    ROUTE `/john` |> Successful.OK johnDoe
 ]
 ```
 
@@ -953,9 +953,9 @@ The simplest form of routing can be done with the `route` http handler:
 
 ```fsharp
 let webApp =
-    choose [
-        route "/foo" >=> text "Foo"
-        route "/bar" >=> text "Bar"
+    CHOOSE [
+        ROUTE "/foo" |> text "Foo"
+        ROUTE "/bar" |> text "Bar"
 
         // If none of the routes matched then return a 404
         RequestErrors.NOT_FOUND "Not Found"
@@ -970,9 +970,9 @@ This can be avoided by using the case insensitive `routeCi` http handler:
 
 ```fsharp
 let webApp =
-    choose [
-        route   "/foo" >=> text "Foo"
-        routeCi "/foo" >=> text "Bar"
+    CHOOSE [
+        ROUTE   "/foo" |> text "Foo"
+        ROUTE_CI "/foo" |> text "Bar"
 
         // If none of the routes matched then return a 404
         RequestErrors.NOT_FOUND "Not Found"
@@ -994,9 +994,9 @@ A web server might (rightfully) want to serve a different response for each rout
 
 ```fsharp
 let webApp =
-    choose [
-        route "/foo"  >=> text "Foo"
-        route "/foo/" >=> text "Bar"
+    CHOOSE [
+        ROUTE "/foo"  |> text "Foo"
+        ROUTE "/foo/" |> text "Bar"
 
         // If none of the routes matched then return a 404
         RequestErrors.NOT_FOUND "Not Found"
@@ -1007,8 +1007,8 @@ However many web applications choose to treat both routes as the same. If you wo
 
 ```fsharp
 let webApp =
-    choose [
-        routex "/foo(/?)" >=> text "Bar"
+    CHOOSE [
+        ROUTE_X "/foo(/?)" |> text "Bar"
 
         // If none of the routes matched then return a 404
         RequestErrors.NOT_FOUND "Not Found"
@@ -1026,8 +1026,8 @@ However, this example wouldn't match a request made to `https://example.org/foo/
 
 ```fsharp
 let webApp =
-    choose [
-        routex "/foo(/*)" >=> text "Bar"
+    CHOOSE [
+        ROUTE_X "/foo(/*)" |> text "Bar"
 
         // If none of the routes matched then return a 404
         RequestErrors.NOT_FOUND "Not Found"

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ open Giraffe
 
 let webApp =
     choose [
-        route "/ping"   >=> text "pong"
-        route "/"       >=> htmlFile "/pages/index.html" ]
+        route "/ping"   >> text "pong"
+        route "/"       >> htmlFile "/pages/index.html" ]
 
 type Startup() =
     member __.ConfigureServices (services : IServiceCollection) =
@@ -133,8 +133,8 @@ open Giraffe
 
 let webApp =
     choose [
-        route "/ping"   >=> text "pong"
-        route "/"       >=> htmlFile "/pages/index.html" ]
+        route "/ping"   >> text "pong"
+        route "/"       >> htmlFile "/pages/index.html" ]
 
 let configureApp (app : IApplicationBuilder) =
     // Add Giraffe to the ASP.NET Core pipeline

--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ open Microsoft.Extensions.DependencyInjection
 open Giraffe
 
 let webApp =
-    choose [
-        route "/ping"   >> text "pong"
-        route "/"       >> htmlFile "/pages/index.html" ]
+    CHOOSE [
+        ROUTE "/ping"   |> text "pong"
+        ROUTE "/"       |> htmlFile "/pages/index.html" ]
 
 type Startup() =
     member __.ConfigureServices (services : IServiceCollection) =
@@ -132,9 +132,9 @@ open Microsoft.Extensions.DependencyInjection
 open Giraffe
 
 let webApp =
-    choose [
-        route "/ping"   >> text "pong"
-        route "/"       >> htmlFile "/pages/index.html" ]
+    CHOOSE [
+        ROUTE "/ping"   |> text "pong"
+        ROUTE "/"       |> htmlFile "/pages/index.html" ]
 
 let configureApp (app : IApplicationBuilder) =
     // Add Giraffe to the ASP.NET Core pipeline
@@ -208,7 +208,7 @@ Running `dotnet test` from the root of the project will execute all test project
 
 ```
 dotnet test
-``` 
+```
 
 ## Contributing
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+## 6.0.0
+
+- Same as 6.0.0-alpha-2
+
 ## 6.0.0-alpha-2
 
 - Added `setContentType` handler

--- a/samples/EndpointRoutingApp/EndpointRoutingApp/Program.fs
+++ b/samples/EndpointRoutingApp/EndpointRoutingApp/Program.fs
@@ -1,4 +1,4 @@
-﻿open System
+open System
 open Microsoft.AspNetCore
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
@@ -8,20 +8,25 @@ open Microsoft.Extensions.Hosting
 open Giraffe
 open Giraffe.EndpointRouting
 
-let handler1 : HttpHandler =
-    fun (_ : HttpFunc) (ctx : HttpContext) ->
-        ctx.WriteTextAsync "Hello World"
+let handler1 source : HttpHandler =
+    fun (_ : HttpFunc) ->
+        fun (ctx : HttpContext) ->
+            ctx.WriteTextAsync "Hello World"
+        |> source
 
-let handler2 (firstName : string, age : int) : HttpHandler =
-    fun (_ : HttpFunc) (ctx : HttpContext) ->
-        sprintf "Hello %s, you are %i years old." firstName age
-        |> ctx.WriteTextAsync
+let handler2 (firstName : string, age : int) source : HttpHandler =
+    fun (_ : HttpFunc) ->
+        fun (ctx : HttpContext) ->
+            sprintf "Hello %s, you are %i years old." firstName age
+            |> ctx.WriteTextAsync
+        |> source
 
-let handler3 (a : string, b : string, c : string, d : int) : HttpHandler =
-    fun (_ : HttpFunc) (ctx : HttpContext) ->
-        sprintf "Hello %s %s %s %i" a b c d
-        |> ctx.WriteTextAsync
-
+let handler3 (a : string, b : string, c : string, d : int) source : HttpHandler =
+    fun (_ : HttpFunc) ->
+        fun (ctx : HttpContext) ->
+            sprintf "Hello %s %s %s %i" a b c d
+            |> ctx.WriteTextAsync
+        |> source
 let endpoints =
     [
         subRoute "/foo" [
@@ -45,9 +50,8 @@ let endpoints =
         ]
     ]
 
-let notFoundHandler =
-    "Not Found"
-    |> text
+let notFoundHandler : HttpHandler =
+    TEXT "Not Found"
     |> RequestErrors.notFound
 
 let configureApp (appBuilder : IApplicationBuilder) =
@@ -71,7 +75,7 @@ let main args =
 
     if app.Environment.IsDevelopment() then
         app.UseDeveloperExceptionPage() |> ignore
-    
+
     configureApp app
     app.Run()
 

--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -238,17 +238,18 @@ module Core =
     /// <param name="next"></param>
     /// <param name="ctx"></param>
     /// <returns>A Giraffe <see cref="HttpHandler"/> function which can be composed into a bigger web application.</returns>
-    let mustAccept (mimeTypes : string list) source : HttpHandler =
+    let mustAccept (mimeTypes : string list) (source: HttpHandler) : HttpHandler =
         let acceptedMimeTypes : MediaTypeHeaderValue list = mimeTypes |> List.map (MediaTypeHeaderValue.Parse)
-        fun (next : HttpFunc) (ctx : HttpContext) ->
-            let headers = ctx.Request.GetTypedHeaders()
-            headers.Accept
-            |> Seq.exists (fun h ->
-                acceptedMimeTypes
-                |> List.exists (fun amt -> amt.IsSubsetOf(h)))
-            |> function
-                | true  -> next ctx
-                | false -> skipPipeline
+        fun (next : HttpFunc) ->
+            fun (ctx : HttpContext) ->
+                let headers = ctx.Request.GetTypedHeaders()
+                headers.Accept
+                |> Seq.exists (fun h ->
+                    acceptedMimeTypes
+                    |> List.exists (fun amt -> amt.IsSubsetOf(h)))
+                |> function
+                    | true  -> next ctx
+                    | false -> skipPipeline
             |> source
 
     /// <summary>

--- a/src/Giraffe/Core.fs
+++ b/src/Giraffe/Core.fs
@@ -7,6 +7,7 @@ module Core =
     open System.Globalization
     open Microsoft.AspNetCore.Http
     open Microsoft.Extensions.Logging
+    open Microsoft.Net.Http.Headers
     open Giraffe.ViewEngine
 
     /// <summary>
@@ -227,11 +228,13 @@ module Core =
     /// <param name="ctx"></param>
     /// <returns>A Giraffe <see cref="HttpHandler"/> function which can be composed into a bigger web application.</returns>
     let mustAccept (mimeTypes : string list) : HttpHandler =
+        let acceptedMimeTypes : MediaTypeHeaderValue list = mimeTypes |> List.map (MediaTypeHeaderValue.Parse)
         fun (next : HttpFunc) (ctx : HttpContext) ->
             let headers = ctx.Request.GetTypedHeaders()
             headers.Accept
-            |> Seq.map    (fun h -> h.ToString())
-            |> Seq.exists (fun h -> mimeTypes |> Seq.contains h)
+            |> Seq.exists (fun h ->
+                acceptedMimeTypes
+                |> List.exists (fun amt -> amt.IsSubsetOf(h)))
             |> function
                 | true  -> next ctx
                 | false -> skipPipeline

--- a/src/Giraffe/Helpers.fs
+++ b/src/Giraffe/Helpers.fs
@@ -7,7 +7,7 @@ module Helpers =
     open Microsoft.IO
 
     /// <summary>Default single RecyclableMemoryStreamManager.</summary>
-    let recyclableMemoryStreamManager = Lazy<RecyclableMemoryStreamManager>()
+    let internal recyclableMemoryStreamManager = Lazy<RecyclableMemoryStreamManager>()
 
     /// <summary>
     /// Checks if an object is not null.

--- a/src/Giraffe/HttpContextExtensions.fs
+++ b/src/Giraffe/HttpContextExtensions.fs
@@ -5,6 +5,7 @@ open System.IO
 open System.Text
 open System.Globalization
 open System.Runtime.CompilerServices
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Http.Extensions
 open Microsoft.AspNetCore.Hosting
@@ -340,7 +341,7 @@ type HttpContextExtensions() =
     /// <param name="bytes">The byte array to be send back to the client.</param>
     /// <returns>Task of Some HttpContext after writing to the body of the response.</returns>
     [<Extension>]
-    static member WriteBytesAsync (ctx : HttpContext, bytes : byte[]) =
+    static member WriteBytesAsync (ctx : HttpContext, bytes : byte[]) : Task<HttpContext option> =
         task {
             ctx.SetHttpHeader(HeaderNames.ContentLength, bytes.Length)
             if ctx.Request.Method <> HttpMethods.Head then

--- a/src/Giraffe/HttpStatusCodeHandlers.fs
+++ b/src/Giraffe/HttpStatusCodeHandlers.fs
@@ -1,33 +1,35 @@
 [<AutoOpen>]
 module Giraffe.HttpStatusCodeHandlers
 
+open System.Net
+
 /// <summary>
 /// A collection of <see cref="HttpHandler" /> functions to return HTTP status code 1xx responses.
 /// </summary>
 module Intermediate =
-    let CONTINUE        : HttpHandler = setStatusCode 100 >=> setBody [||]
-    let SWITCHING_PROTO : HttpHandler = setStatusCode 101 >=> setBody [||]
+    let CONTINUE        : HttpHandler -> HttpHandler = setStatusCode 100 >> setBody [||]
+    let SWITCHING_PROTO : HttpHandler -> HttpHandler = setStatusCode 101 >> setBody [||]
 
 /// <summary>
 /// A collection of <see cref="HttpHandler" /> functions to return HTTP status code 2xx responses.
 /// </summary>
 module Successful =
-    let ok x        = setStatusCode 200 >=> x
+    let ok x        = setStatusCode 200 >> x
     let OK x        = ok (negotiate x)
 
-    let created x   = setStatusCode 201 >=> x
+    let created x   = setStatusCode 201 >> x
     let CREATED x   = created (negotiate x)
 
-    let accepted x  = setStatusCode 202 >=> x
+    let accepted x  = setStatusCode 202 >> x
     let ACCEPTED x  = accepted (negotiate x)
 
-    let NO_CONTENT : HttpHandler = setStatusCode 204
+    let NO_CONTENT : HttpHandler -> HttpHandler = setStatusCode 204
 
 /// <summary>
 /// A collection of <see cref="HttpHandler" /> functions to return HTTP status code 4xx responses.
 /// </summary>
 module RequestErrors =
-    let badRequest x  = setStatusCode 400 >=> x
+    let badRequest x  = setStatusCode 400 >> x
     let BAD_REQUEST x = badRequest (negotiate x)
 
     /// <summary>
@@ -45,38 +47,38 @@ module RequestErrors =
     /// </remarks>
     let unauthorized scheme realm x =
         setStatusCode 401
-        >=> setHttpHeader "WWW-Authenticate" (sprintf "%s realm=\"%s\"" scheme realm)
-        >=> x
+        >> setHttpHeader "WWW-Authenticate" (sprintf "%s realm=\"%s\"" scheme realm)
+        >> x
     let UNAUTHORIZED scheme realm x = unauthorized scheme realm (negotiate x)
 
-    let forbidden x                 = setStatusCode 403 >=> x
+    let forbidden x                 = setStatusCode 403 >> x
     let FORBIDDEN x                 = forbidden (negotiate x)
 
-    let notFound x                  = setStatusCode 404 >=> x
-    let NOT_FOUND x                 = notFound (negotiate x)
+    let notFound x                  = x |> setStatusCode 404
+    let NOT_FOUND x                 = notFound (empty |> negotiate x)
 
-    let methodNotAllowed x          = setStatusCode 405 >=> x
-    let METHOD_NOT_ALLOWED x        = methodNotAllowed (negotiate x)
+    let methodNotAllowed (x: HttpHandler)          = x |> setStatusCode 405
+    let METHOD_NOT_ALLOWED (x: obj):  HttpHandler        = methodNotAllowed (empty |> negotiate x)
 
-    let notAcceptable x             = setStatusCode 406 >=> x
+    let notAcceptable x             = setStatusCode 406 >> x
     let NOT_ACCEPTABLE x            = notAcceptable (negotiate x)
 
-    let conflict x                  = setStatusCode 409 >=> x
+    let conflict x                  = setStatusCode 409 >> x
     let CONFLICT x                  = conflict (negotiate x)
 
-    let gone x                      = setStatusCode 410 >=> x
+    let gone x                      = setStatusCode 410 >> x
     let GONE x                      = gone (negotiate x)
 
-    let unsupportedMediaType x      = setStatusCode 415 >=> x
+    let unsupportedMediaType x      = setStatusCode 415 >> x
     let UNSUPPORTED_MEDIA_TYPE x    = unsupportedMediaType (negotiate x)
 
-    let unprocessableEntity x       = setStatusCode 422 >=> x
+    let unprocessableEntity x       = setStatusCode 422 >> x
     let UNPROCESSABLE_ENTITY x      = unprocessableEntity (negotiate x)
 
-    let preconditionRequired x      = setStatusCode 428 >=> x
+    let preconditionRequired x      = setStatusCode 428 >> x
     let PRECONDITION_REQUIRED x     = preconditionRequired (negotiate x)
 
-    let tooManyRequests x           = setStatusCode 429 >=> x
+    let tooManyRequests x           = setStatusCode 429 >> x
     let TOO_MANY_REQUESTS x         = tooManyRequests (negotiate x)
 
 
@@ -84,19 +86,19 @@ module RequestErrors =
 /// A collection of <see cref="HttpHandler" /> functions to return HTTP status code 5xx responses.
 /// </summary>
 module ServerErrors =
-    let internalError x         = setStatusCode 500 >=> x
+    let internalError x         = setStatusCode 500 >> x
     let INTERNAL_ERROR x        = internalError (negotiate x)
 
-    let notImplemented x        = setStatusCode 501 >=> x
+    let notImplemented x        = setStatusCode 501 >> x
     let NOT_IMPLEMENTED x       = notImplemented (negotiate x)
 
-    let badGateway x            = setStatusCode 502 >=> x
+    let badGateway x            = setStatusCode 502 >> x
     let BAD_GATEWAY x           = badGateway (negotiate x)
 
-    let serviceUnavailable x    = setStatusCode 503 >=> x
+    let serviceUnavailable x    = setStatusCode 503 >> x
     let SERVICE_UNAVAILABLE x   = serviceUnavailable (negotiate x)
 
-    let gatewayTimeout x        = setStatusCode 504 >=> x
+    let gatewayTimeout x        = setStatusCode 504 >> x
     let GATEWAY_TIMEOUT x       = gatewayTimeout (negotiate x)
 
-    let invalidHttpVersion x    = setStatusCode 505 >=> x
+    let invalidHttpVersion x    = setStatusCode 505 >> x

--- a/src/Giraffe/Middleware.fs
+++ b/src/Giraffe/Middleware.fs
@@ -45,7 +45,7 @@ type GiraffeMiddleware (next          : RequestDelegate,
                     ctx.Request.Path.ToString(),
                     elapsedMs)
 
-            if (result.IsNone) then
+            if result.IsNone then
                 return! next.Invoke ctx
         }
 
@@ -66,7 +66,7 @@ type GiraffeErrorHandlerMiddleware (next          : RequestDelegate,
                 let logger = loggerFactory.CreateLogger<GiraffeErrorHandlerMiddleware>()
                 try
                     let func = (Some >> Task.FromResult)
-                    let! _ = errorHandler ex logger func ctx
+                    let! _ = errorHandler ex logger id func ctx
                     return ()
                 with ex2 ->
                     logger.LogError(EventId(0), ex,  "An unhandled exception has occurred while executing the request.")

--- a/src/Giraffe/ModelValidation.fs
+++ b/src/Giraffe/ModelValidation.fs
@@ -12,7 +12,7 @@ module ModelValidation =
         ///
         /// If the object has a valid state then the function should return the object, otherwise it should return a `HttpHandler` function which is ought to return an error response back to a client.
         /// </summary>
-        abstract member Validate : unit -> Result<'T, HttpHandler>
+        abstract member Validate : unit -> Result<'T, HttpHandler -> HttpHandler>
 
     /// <summary>
     /// Validates an object of type 'T where 'T must have implemented interface <see cref="IModelValidation{T}"/>.
@@ -23,7 +23,7 @@ module ModelValidation =
     /// <param name="model">An instance of type 'T, where 'T must implement interface <see cref="IModelValidation{T}"/>.</param>
     /// <typeparam name="'T"></typeparam>
     /// <returns>A Giraffe <see cref="HttpHandler"/> function which can be composed into a bigger web application.</returns>
-    let validateModel<'T when 'T :> IModelValidation<'T>> (f : 'T -> HttpHandler) (model : 'T) : HttpHandler =
+    let validateModel<'T when 'T :> IModelValidation<'T>> (f : 'T -> HttpHandler ->HttpHandler) (model : 'T) : HttpHandler -> HttpHandler =
         match model.Validate() with
         | Ok _      -> f model
         | Error err -> err

--- a/src/Giraffe/Streaming.fs
+++ b/src/Giraffe/Streaming.fs
@@ -258,9 +258,12 @@ let streamData (enableRangeProcessing : bool)
                (stream                : Stream)
                (eTag                  : EntityTagHeaderValue option)
                (lastModified          : DateTimeOffset option)
+                (source                : HttpHandler)
                : HttpHandler =
-    fun (_ : HttpFunc) (ctx : HttpContext) ->
-        ctx.WriteStreamAsync(enableRangeProcessing, stream, eTag, lastModified)
+    fun (_ : HttpFunc) ->
+        fun (ctx : HttpContext) ->
+            ctx.WriteStreamAsync(enableRangeProcessing, stream, eTag, lastModified)
+        |> source
 
 /// <summary>
 /// Streams a file to the client.
@@ -277,6 +280,9 @@ let streamFile (enableRangeProcessing : bool)
                (filePath              : string)
                (eTag                  : EntityTagHeaderValue option)
                (lastModified          : DateTimeOffset option)
+               (source                : HttpHandler)
                : HttpHandler =
-    fun (_ : HttpFunc) (ctx : HttpContext) ->
-        ctx.WriteFileStreamAsync(enableRangeProcessing, filePath, eTag, lastModified)
+    fun (_ : HttpFunc) ->
+        fun (ctx : HttpContext) ->
+            ctx.WriteFileStreamAsync(enableRangeProcessing, filePath, eTag, lastModified)
+        |> source

--- a/tests/Giraffe.Tests/AuthTests.fs
+++ b/tests/Giraffe.Tests/AuthTests.fs
@@ -37,8 +37,8 @@ module TestApp =
                 | Anonymous       -> ClaimsPrincipal (ClaimsIdentity ())
                 | Authenticated c -> ClaimsPrincipal (ClaimsIdentity (c, "foo"))
 
-    let private accessDenied = setStatusCode 401 >=> text Response.AccessDenied
-    let private ok content   = setStatusCode 200 >=> text content
+    let private accessDenied = setStatusCode 401 >> text Response.AccessDenied
+    let private ok content   = setStatusCode 200 >> text content
 
     let private mustBeLoggedIn = requiresAuthentication accessDenied
     let private mustBeAdmin = requiresRole "admin" accessDenied
@@ -48,12 +48,12 @@ module TestApp =
     let private mustBeJohn = authorizeUser isJohn accessDenied
 
     let app =
-        GET >=> choose [
-            route Route.Anonymous       >=> ok Response.Anonymous
-            route Route.Authenticated   >=> mustBeLoggedIn        >=> ok Response.Authenticated
-            route Route.AdminOnly       >=> mustBeAdmin           >=> ok Response.AdminOnly
-            route Route.AdminOrOperator >=> mustBeOperatorOrAdmin >=> ok Response.AdminOrOperator
-            route Route.JohnOnly        >=> mustBeJohn            >=> ok Response.JohnOnly
+        GET |> choose [
+            ROUTE Route.Anonymous       |> ok Response.Anonymous
+            ROUTE Route.Authenticated   |> mustBeLoggedIn        |> ok Response.Authenticated
+            ROUTE Route.AdminOnly       |> mustBeAdmin           |> ok Response.AdminOnly
+            ROUTE Route.AdminOrOperator |> mustBeOperatorOrAdmin |> ok Response.AdminOrOperator
+            ROUTE Route.JohnOnly        |> mustBeJohn            |> ok Response.JohnOnly
         ]
 
 [<AutoOpen>]

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -395,13 +395,13 @@ let ``POST with "all-medias" header type returns the first available route`` () 
     /// Reference: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
     let ctx = Substitute.For<HttpContext>()
     let app =
-        choose [
-            POST >=> choose [
-                route "/any" >=> mustAccept [ "text/plain" ] >=> text "first route"
-                route "/any" >=> mustAccept [ "application/json" ] >=> json "second route"
-                route "/any" >=> mustAccept [ "text/plain"; "application/json" ] >=> text "third route" ]
-            setStatusCode 404 >=> text "Not found" ]
-        
+        CHOOSE [
+            POST |> choose [
+                ROUTE "/any" |> mustAccept [ "text/plain" ] |> text "first route"
+                ROUTE "/any" |> mustAccept [ "application/json" ] |> json "second route"
+                ROUTE "/any" |> mustAccept [ "text/plain"; "application/json" ] |> text "third route" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
+
     let headers = HeaderDictionary()
     headers.Add("Accept", StringValues("*/*"))
     ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
@@ -420,19 +420,19 @@ let ``POST with "all-medias" header type returns the first available route`` () 
             Assert.Equal(expected, body)
             Assert.Equal("text/plain; charset=utf-8", ctx.Response |> getContentType)
     }
-        
+
 [<Fact>]
 let ``POST with an accept header type containing a fuzzy type and concrete subtype returns the first matching route`` () =
     /// Reference: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
     let ctx = Substitute.For<HttpContext>()
     let app =
-        choose [
-            POST >=> choose [
-                route "/any" >=> mustAccept [ "text/plain" ] >=> text "first route"
-                route "/any" >=> mustAccept [ "application/xml" ] >=> text "<test>second route</test>"
-                route "/any" >=> mustAccept [ "text/plain"; "application/json" ] >=> text "third route" ]
-            setStatusCode 404 >=> text "Not found" ]
-        
+        CHOOSE [
+            POST |> choose [
+                ROUTE "/any" |> mustAccept [ "text/plain" ] |> text "first route"
+                ROUTE "/any" |> mustAccept [ "application/xml" ] |> text "<test>second route</test>"
+                ROUTE "/any" |> mustAccept [ "text/plain"; "application/json" ] |> text "third route" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
+
     let headers = HeaderDictionary()
     headers.Add("Accept", StringValues("application/*"))
     ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -382,6 +382,68 @@ let ``POST "/either" with unsupported Accept header returns 404 "Not found"`` ()
     }
 
 [<Fact>]
+let ``POST with "all-medias" header type returns the first available route`` () =
+    /// Reference: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
+    let ctx = Substitute.For<HttpContext>()
+    let app =
+        choose [
+            POST >=> choose [
+                route "/any" >=> mustAccept [ "text/plain" ] >=> text "first route"
+                route "/any" >=> mustAccept [ "application/json" ] >=> json "second route"
+                route "/any" >=> mustAccept [ "text/plain"; "application/json" ] >=> text "third route" ]
+            setStatusCode 404 >=> text "Not found" ]
+        
+    let headers = HeaderDictionary()
+    headers.Add("Accept", StringValues("*/*"))
+    ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/any")) |> ignore
+    ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = "first route"
+
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None -> assertFail $"Result was expected to be %s{expected}"
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal(expected, body)
+            Assert.Equal("text/plain; charset=utf-8", ctx.Response |> getContentType)
+    }
+        
+[<Fact>]
+let ``POST with an accept header type containing a fuzzy type and concrete subtype returns the first matching route`` () =
+    /// Reference: https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2
+    let ctx = Substitute.For<HttpContext>()
+    let app =
+        choose [
+            POST >=> choose [
+                route "/any" >=> mustAccept [ "text/plain" ] >=> text "first route"
+                route "/any" >=> mustAccept [ "application/xml" ] >=> text "<test>second route</test>"
+                route "/any" >=> mustAccept [ "text/plain"; "application/json" ] >=> text "third route" ]
+            setStatusCode 404 >=> text "Not found" ]
+        
+    let headers = HeaderDictionary()
+    headers.Add("Accept", StringValues("application/*"))
+    ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
+    ctx.Request.Path.ReturnsForAnyArgs (PathString("/any")) |> ignore
+    ctx.Request.Headers.ReturnsForAnyArgs(headers) |> ignore
+    ctx.Response.Body <- new MemoryStream()
+    let expected = "<test>second route</test>"
+
+    task {
+        let! result = app next ctx
+
+        match result with
+        | None -> assertFail $"Result was expected to be %s{expected}"
+        | Some ctx ->
+            let body = getBody ctx
+            Assert.Equal(expected, body)
+            Assert.Equal("text/plain; charset=utf-8", ctx.Response |> getContentType)
+    }
+
+[<Fact>]
 let ``GET "/person" returns rendered HTML view`` () =
     let ctx = Substitute.For<HttpContext>()
 

--- a/tests/Giraffe.Tests/HttpHandlerTests.fs
+++ b/tests/Giraffe.Tests/HttpHandlerTests.fs
@@ -48,11 +48,20 @@ let ``GET "/json" returns json object`` (settings) =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx settings
     let app =
-        GET >=> choose [
-            route "/"     >=> text "Hello World"
-            route "/foo"  >=> text "bar"
-            route "/json" >=> json { Foo = "john"; Bar = "doe"; Age = 30 }
-            setStatusCode 404 >=> text "Not found" ]
+        GET
+        |> choose [
+            ROUTE "/"
+            |> text "Hello World"
+
+            ROUTE "/foo"
+            |> text "bar"
+
+            ROUTE "/json"
+            |> json { Foo = "john"; Bar = "doe"; Age = 30 }
+
+            SET_STATUS_CODE 404
+            |> text "Not found"
+        ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/json")) |> ignore
@@ -74,11 +83,11 @@ let ``GET "/json" with custom json settings returns json object`` (settings) =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx settings
     let app =
-        GET >=> choose [
-            route "/"     >=> text "Hello World"
-            route "/foo"  >=> text "bar"
-            route "/json" >=> json { Foo = "john"; Bar = "doe"; Age = 30 }
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE "/"     |> text "Hello World"
+            ROUTE "/foo"  |> text "bar"
+            ROUTE "/json" |> json { Foo = "john"; Bar = "doe"; Age = 30 }
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/json")) |> ignore
@@ -107,11 +116,11 @@ let ``GET "/jsonChunked" returns json object`` (size: int, settings) =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx settings
     let app =
-        GET >=> choose [
-            route "/"     >=> text "Hello World"
-            route "/foo"  >=> text "bar"
-            route "/jsonChunked" >=> json ( Array.replicate size { Foo = "john"; Bar = "doe"; Age = 30 } )
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE "/"     |> text "Hello World"
+            ROUTE "/foo"  |> text "bar"
+            ROUTE "/jsonChunked" |> json ( Array.replicate size { Foo = "john"; Bar = "doe"; Age = 30 } )
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/jsonChunked")) |> ignore
@@ -144,11 +153,11 @@ let ``GET "/jsonChunked" with custom json settings returns json object`` (size: 
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx settings
     let app =
-        GET >=> choose [
-            route "/"     >=> text "Hello World"
-            route "/foo"  >=> text "bar"
-            route "/jsonChunked" >=> json ( Array.replicate size { Foo = "john"; Bar = "doe"; Age = 30 } )
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE "/"     |> text "Hello World"
+            ROUTE "/foo"  |> text "bar"
+            ROUTE "/jsonChunked" |> json ( Array.replicate size { Foo = "john"; Bar = "doe"; Age = 30 } )
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/jsonChunked")) |> ignore
@@ -171,14 +180,14 @@ let ``GET "/jsonChunked" with custom json settings returns json object`` (size: 
 let ``POST "/post/1" returns "1"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        choose [
-            GET >=> choose [
-                route "/"     >=> text "Hello World"
-                route "/foo"  >=> text "bar" ]
-            POST >=> choose [
-                route "/post/1" >=> text "1"
-                route "/post/2" >=> text "2" ]
-            setStatusCode 404 >=> text "Not found" ]
+        CHOOSE [
+            GET |> choose [
+                ROUTE "/"     |> text "Hello World"
+                ROUTE "/foo"  |> text "bar" ]
+            POST |> choose [
+                ROUTE "/post/1" |> text "1"
+                ROUTE "/post/2" |> text "2" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/post/1")) |> ignore
@@ -197,14 +206,14 @@ let ``POST "/post/1" returns "1"`` () =
 let ``POST "/post/2" returns "2"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        choose [
-            GET >=> choose [
-                route "/"     >=> text "Hello World"
-                route "/foo"  >=> text "bar" ]
-            POST >=> choose [
-                route "/post/1" >=> text "1"
-                route "/post/2" >=> text "2" ]
-            setStatusCode 404 >=> text "Not found" ]
+        CHOOSE [
+            GET |> choose [
+                ROUTE "/"     |> text "Hello World"
+                ROUTE "/foo"  |> text "bar" ]
+            POST |> choose [
+                ROUTE "/post/1" |> text "1"
+                ROUTE "/post/2" |> text "2" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/post/2")) |> ignore
@@ -223,14 +232,14 @@ let ``POST "/post/2" returns "2"`` () =
 let ``PUT "/post/2" returns 404 "Not found"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        choose [
-            GET >=> choose [
-                route "/"     >=> text "Hello World"
-                route "/foo"  >=> text "bar" ]
-            POST >=> choose [
-                route "/post/1" >=> text "1"
-                route "/post/2" >=> text "2" ]
-            setStatusCode 404 >=> text "Not found" ]
+        CHOOSE [
+            GET |> choose [
+                ROUTE "/"     |> text "Hello World"
+                ROUTE "/foo"  |> text "bar" ]
+            POST |> choose [
+                ROUTE "/post/1" |> text "1"
+                ROUTE "/post/2" |> text "2" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "PUT" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/post/2")) |> ignore
@@ -252,15 +261,15 @@ let ``PUT "/post/2" returns 404 "Not found"`` () =
 let ``POST "/text" with supported Accept header returns "text"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        choose [
-            GET >=> choose [
-                route "/"     >=> text "Hello World"
-                route "/foo"  >=> text "bar" ]
-            POST >=> choose [
-                route "/text"   >=> mustAccept [ "text/plain" ] >=> text "text"
-                route "/json"   >=> mustAccept [ "application/json" ] >=> json "json"
-                route "/either" >=> mustAccept [ "text/plain"; "application/json" ] >=> text "either" ]
-            setStatusCode 404 >=> text "Not found" ]
+        CHOOSE [
+            GET |> choose [
+                ROUTE "/"     |> text "Hello World"
+                ROUTE "/foo"  |> text "bar" ]
+            POST |> choose [
+                ROUTE "/text"   |> mustAccept [ "text/plain" ] |> text "text"
+                ROUTE "/json"   |> mustAccept [ "application/json" ] |> json "json"
+                ROUTE "/either" |> mustAccept [ "text/plain"; "application/json" ] |> text "either" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     let headers = HeaderDictionary()
     headers.Add("Accept", StringValues("text/plain"))
@@ -286,15 +295,15 @@ let ``POST "/json" with supported Accept header returns "json"`` () =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx ( Newtonsoft None )
     let app =
-        choose [
-            GET >=> choose [
-                route "/"     >=> text "Hello World"
-                route "/foo"  >=> text "bar" ]
-            POST >=> choose [
-                route "/text"   >=> mustAccept [ "text/plain" ] >=> text "text"
-                route "/json"   >=> mustAccept [ "application/json" ] >=> json "json"
-                route "/either" >=> mustAccept [ "text/plain"; "application/json" ] >=> text "either" ]
-            setStatusCode 404 >=> text "Not found" ]
+        CHOOSE [
+            GET |> choose [
+                ROUTE "/"     |> text "Hello World"
+                ROUTE "/foo"  |> text "bar" ]
+            POST |> choose [
+                ROUTE "/text"   |> mustAccept [ "text/plain" ] |> text "text"
+                ROUTE "/json"   |> mustAccept [ "application/json" ] |> json "json"
+                ROUTE "/either" |> mustAccept [ "text/plain"; "application/json" ] |> text "either" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     let headers = HeaderDictionary()
     headers.Add("Accept", StringValues("application/json"))
@@ -319,15 +328,15 @@ let ``POST "/json" with supported Accept header returns "json"`` () =
 let ``POST "/either" with supported Accept header returns "either"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        choose [
-            GET >=> choose [
-                route "/"     >=> text "Hello World"
-                route "/foo"  >=> text "bar" ]
-            POST >=> choose [
-                route "/text"   >=> mustAccept [ "text/plain" ] >=> text "text"
-                route "/json"   >=> mustAccept [ "application/json" ] >=> json "json"
-                route "/either" >=> mustAccept [ "text/plain"; "application/json" ] >=> text "either" ]
-            setStatusCode 404 >=> text "Not found" ]
+        CHOOSE [
+            GET |> choose [
+                ROUTE "/"     |> text "Hello World"
+                ROUTE "/foo"  |> text "bar" ]
+            POST |> choose [
+                ROUTE "/text"   |> mustAccept [ "text/plain" ] |> text "text"
+                ROUTE "/json"   |> mustAccept [ "application/json" ] |> json "json"
+                ROUTE "/either" |> mustAccept [ "text/plain"; "application/json" ] |> text "either" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     let headers = HeaderDictionary()
     headers.Add("Accept", StringValues("application/json"))
@@ -352,15 +361,15 @@ let ``POST "/either" with supported Accept header returns "either"`` () =
 let ``POST "/either" with unsupported Accept header returns 404 "Not found"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        choose [
-            GET >=> choose [
-                route "/"     >=> text "Hello World"
-                route "/foo"  >=> text "bar" ]
-            POST >=> choose [
-                route "/text"   >=> mustAccept [ "text/plain" ] >=> text "text"
-                route "/json"   >=> mustAccept [ "application/json" ] >=> json "json"
-                route "/either" >=> mustAccept [ "text/plain"; "application/json" ] >=> text "either" ]
-            setStatusCode 404 >=> text "Not found" ]
+        CHOOSE [
+            GET |> choose [
+                ROUTE "/"     |> text "Hello World"
+                ROUTE "/foo"  |> text "bar" ]
+            POST |> choose [
+                ROUTE "/text"   |> mustAccept [ "text/plain" ] |> text "text"
+                ROUTE "/json"   |> mustAccept [ "application/json" ] |> json "json"
+                ROUTE "/either" |> mustAccept [ "text/plain"; "application/json" ] |> text "either" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     let headers = HeaderDictionary()
     headers.Add("Accept", StringValues("application/xml"))
@@ -398,13 +407,13 @@ let ``GET "/person" returns rendered HTML view`` () =
     let johnDoe = { Foo = "John"; Bar = "Doe"; Age = 30 }
 
     let app =
-        choose [
-            GET >=> choose [
-                route "/"          >=> text "Hello World"
-                route "/person"    >=> (personView johnDoe |> htmlView) ]
-            POST >=> choose [
-                route "/post/1"    >=> text "1" ]
-            setStatusCode 404      >=> text "Not found" ]
+        CHOOSE [
+            GET |> choose [
+                ROUTE "/"          |> text "Hello World"
+                ROUTE "/person"    |> (personView johnDoe |> htmlView) ]
+            POST |> choose [
+                ROUTE "/post/1"    |> text "1" ]
+            SET_STATUS_CODE 404      |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/person")) |> ignore
@@ -427,9 +436,9 @@ let ``Warbler function should execute inner function each time`` () =
     let ctx = Substitute.For<HttpContext>()
     let inner() = Guid.NewGuid().ToString()
     let app =
-        GET >=> choose [
-            route "/foo"  >=> text (inner())
-            route "/foo2" >=> warbler (fun _ -> text (inner())) ]
+        GET |> choose [
+            ROUTE "/foo"  |> text (inner())
+            ROUTE "/foo2" |> warbler (fun _ -> text (inner())) ]
         <| next
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -465,10 +474,10 @@ let ``Warbler function should execute inner function each time`` () =
 let ``GET "/redirect" redirect to "/" `` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route "/"         >=> text "Hello World"
-            route "/redirect" >=> redirectTo false "/"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE "/"         |> text "Hello World"
+            ROUTE "/redirect" |> redirectTo false "/"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/redirect")) |> ignore
@@ -486,10 +495,10 @@ let ``GET "/redirect" redirect to "/" `` () =
 let ``POST "/redirect" redirect to "/" `` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        POST >=> choose [
-            route "/"         >=> text "Hello World"
-            route "/redirect" >=> redirectTo true "/"
-            setStatusCode 404 >=> text "Not found" ]
+        POST |> choose [
+            ROUTE "/"         |> text "Hello World"
+            ROUTE "/redirect" |> redirectTo true "/"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/redirect")) |> ignore
@@ -554,11 +563,11 @@ let getNegotiationTestHttpContext
     ctx
 
 let negotiationTestApp =
-    GET >=> choose [
-        route "/"     >=> text "Hello World"
-        route "/foo"  >=> text "bar"
-        route "/auto" >=> negotiate johnDoe
-        setStatusCode 404 >=> text "Not found" ]
+    GET |> choose [
+        ROUTE "/"     |> text "Hello World"
+        ROUTE "/foo"  |> text "bar"
+        ROUTE "/auto" |> negotiate johnDoe
+        SET_STATUS_CODE 404 |> text "Not found" ]
 
 let runNegotiationTest (ctx : HttpContext) (expectedString : string) (testChecks : HttpContext -> unit) =
     task {

--- a/tests/Giraffe.Tests/ModelValidationTests.fs
+++ b/tests/Giraffe.Tests/ModelValidationTests.fs
@@ -53,15 +53,15 @@ module WebApp =
     let tryBindQueryToAdult = tryBindQuery<Adult> parsingErrorHandler culture
 
     let webApp _ =
-        choose [
-            route Urls.person
-            >=> tryBindQueryToAdult (validateModel textHandler)
+        CHOOSE [
+            ROUTE Urls.person
+            |> tryBindQueryToAdult (validateModel textHandler)
         ]
 
-    let errorHandler (ex : Exception) (_ : ILogger) : HttpHandler =
+    let errorHandler (ex : Exception) (_ : ILogger) : HttpHandler -> HttpHandler =
         printfn "Error: %s" ex.Message
         printfn "StackTrace:%s %s" Environment.NewLine ex.StackTrace
-        setStatusCode 500 >=> text ex.Message
+        setStatusCode 500 >> text ex.Message
 
     let configureApp args (app : IApplicationBuilder) =
         app.UseGiraffeErrorHandler(errorHandler)

--- a/tests/Giraffe.Tests/PreconditionalTests.fs
+++ b/tests/Giraffe.Tests/PreconditionalTests.fs
@@ -48,20 +48,20 @@ module Urls =
     let rangeProcessingDisabled = "/range-processing-disabled"
 
 module WebApp =
-    let streamHandler (enableRangeProcessing : bool) args : HttpHandler =
+    let streamHandler (enableRangeProcessing : bool) args : HttpHandler -> HttpHandler =
         args
         ||> streamFile enableRangeProcessing "streaming2.txt"
 
     let webApp args =
-        choose [
-            route Urls.rangeProcessingEnabled  >=> streamHandler true args
-            route Urls.rangeProcessingDisabled >=> streamHandler false args
+        CHOOSE [
+            ROUTE Urls.rangeProcessingEnabled  |> streamHandler true args
+            ROUTE Urls.rangeProcessingDisabled |> streamHandler false args
         ]
 
-    let errorHandler (ex : Exception) (_ : ILogger) : HttpHandler =
+    let errorHandler (ex : Exception) (_ : ILogger) : HttpHandler -> HttpHandler =
         printfn "Error: %s" ex.Message
         printfn "StackTrace:%s %s" Environment.NewLine ex.StackTrace
-        setStatusCode 500 >=> text ex.Message
+        setStatusCode 500 >> text ex.Message
 
     let configureApp args (app : IApplicationBuilder) =
         app.UseGiraffeErrorHandler(errorHandler)

--- a/tests/Giraffe.Tests/RoutingTests.fs
+++ b/tests/Giraffe.Tests/RoutingTests.fs
@@ -16,10 +16,10 @@ open Giraffe
 let ``route: GET "/" returns "Hello World"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route "/"    >=> text "Hello World"
-            route "/foo" >=> text "bar"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE "/"    |> text "Hello World"
+            ROUTE "/foo" |> text "bar"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/")) |> ignore
@@ -38,10 +38,10 @@ let ``route: GET "/" returns "Hello World"`` () =
 let ``route: GET "/foo" returns "bar"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route "/"    >=> text "Hello World"
-            route "/foo" >=> text "bar"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE "/"    |> text "Hello World"
+            ROUTE "/foo" |> text "bar"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo")) |> ignore
@@ -60,10 +60,10 @@ let ``route: GET "/foo" returns "bar"`` () =
 let ``route: GET "/FOO" returns 404 "Not found"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route "/"    >=> text "Hello World"
-            route "/foo" >=> text "bar"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE "/"    |> text "Hello World"
+            ROUTE "/foo" |> text "bar"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/FOO")) |> ignore
@@ -90,12 +90,12 @@ let ``GET "/JSON" returns "BaR"`` () =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx (Newtonsoft None)
     let app =
-        GET >=> choose [
-            route   "/"       >=> text "Hello World"
-            route   "/foo"    >=> text "bar"
-            route   "/json"   >=> text "FOO"
-            routeCi "/json"   >=> text "BaR"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE   "/"       |> text "Hello World"
+            ROUTE   "/foo"    |> text "bar"
+            ROUTE   "/json"   |> text "FOO"
+            ROUTE_CI "/json"   |> text "BaR"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/JSON")) |> ignore
@@ -118,10 +118,10 @@ let ``GET "/JSON" returns "BaR"`` () =
 let ``routex: GET "/" returns "Hello World"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            routex "/"    >=> text "Hello World"
-            routex "/foo" >=> text "bar"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE_X "/"    |> text "Hello World"
+            ROUTE_X "/foo" |> text "bar"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/")) |> ignore
@@ -140,10 +140,10 @@ let ``routex: GET "/" returns "Hello World"`` () =
 let ``routex: GET "/foo" returns "bar"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            routex "/"    >=> text "Hello World"
-            routex "/foo" >=> text "bar"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE_X "/"    |> text "Hello World"
+            ROUTE_X "/foo" |> text "bar"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo")) |> ignore
@@ -162,10 +162,10 @@ let ``routex: GET "/foo" returns "bar"`` () =
 let ``routex: GET "/FOO" returns 404 "Not found"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            routex "/"    >=> text "Hello World"
-            routex "/foo" >=> text "bar"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE_X "/"    |> text "Hello World"
+            ROUTE_X "/foo" |> text "bar"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/FOO")) |> ignore
@@ -187,10 +187,10 @@ let ``routex: GET "/FOO" returns 404 "Not found"`` () =
 let ``routex: GET "/foo///" returns "bar"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            routex "/"        >=> text "Hello World"
-            routex "/foo(/*)" >=> text "bar"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE_X "/"        |> text "Hello World"
+            ROUTE_X "/foo(/*)" |> text "bar"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo///")) |> ignore
@@ -209,10 +209,10 @@ let ``routex: GET "/foo///" returns "bar"`` () =
 let ``routex: GET "/foo2" returns "bar"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            routex "/"         >=> text "Hello World"
-            routex "/foo2(/*)" >=> text "bar"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE_X "/"         |> text "Hello World"
+            ROUTE_X "/foo2(/*)" |> text "bar"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo2")) |> ignore
@@ -235,10 +235,10 @@ let ``routex: GET "/foo2" returns "bar"`` () =
 let ``routeCix: GET "/CaSe///" returns "right"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            routex   "/case(/*)" >=> text "wrong"
-            routeCix "/case(/*)" >=> text "right"
-            setStatusCode 404    >=> text "Not found" ]
+        GET |> choose [
+            ROUTE_X   "/case(/*)" |> text "wrong"
+            empty |> routeCix "/case(/*)" |> text "right"
+            SET_STATUS_CODE 404    |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/CaSe///")) |> ignore
@@ -261,12 +261,12 @@ let ``routeCix: GET "/CaSe///" returns "right"`` () =
 let ``routef: GET "/foo/blah blah/bar" returns "blah blah"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route   "/"       >=> text "Hello World"
-            route   "/foo"    >=> text "bar"
-            routef "/foo/%s/bar" text
-            routef "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE   "/"       |> text "Hello World"
+            ROUTE   "/foo"    |> text "bar"
+            ROUTE_F "/foo/%s/bar" text
+            ROUTE_F "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo/blah blah/bar")) |> ignore
@@ -285,12 +285,12 @@ let ``routef: GET "/foo/blah blah/bar" returns "blah blah"`` () =
 let ``routef: GET "/foo/johndoe/59" returns "Name: johndoe, Age: 59"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route   "/"       >=> text "Hello World"
-            route   "/foo"    >=> text "bar"
-            routef "/foo/%s/bar" text
-            routef "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE   "/"       |> text "Hello World"
+            ROUTE   "/foo"    |> text "bar"
+            ROUTE_F "/foo/%s/bar" text
+            ROUTE_F "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo/johndoe/59")) |> ignore
@@ -309,12 +309,12 @@ let ``routef: GET "/foo/johndoe/59" returns "Name: johndoe, Age: 59"`` () =
 let ``routef: GET "/foo/b%2Fc/bar" returns "b%2Fc"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route  "/"       >=> text "Hello World"
-            route  "/foo"    >=> text "bar"
-            routef "/foo/%s/bar" text
-            routef "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE  "/"       |> text "Hello World"
+            ROUTE  "/foo"    |> text "bar"
+            ROUTE_F "/foo/%s/bar" text
+            ROUTE_F "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo/b%2Fc/bar")) |> ignore
@@ -333,12 +333,12 @@ let ``routef: GET "/foo/b%2Fc/bar" returns "b%2Fc"`` () =
 let ``routef: GET "/foo/a%2Fb%2Bc.d%2Ce/bar" returns "a%2Fb%2Bc.d%2Ce"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route  "/"       >=> text "Hello World"
-            route  "/foo"    >=> text "bar"
-            routef "/foo/%s/bar" text
-            routef "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE  "/"       |> text "Hello World"
+            ROUTE  "/foo"    |> text "bar"
+            ROUTE_F "/foo/%s/bar" text
+            ROUTE_F "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo/a%2Fb%2Bc.d%2Ce/bar")) |> ignore
@@ -364,10 +364,10 @@ let ``routef: GET "/foo/a%2Fb%2Bc.d%2Ce/bar" returns "a%2Fb%2Bc.d%2Ce"`` () =
 let ``routeStartsWith(f|Cif)`` (uri:string, expected:string) =
 
     let app =
-        GET >=> choose [
-            routeStartsWithf "/API/%s/" (fun capture -> text ("routeStartsWithf:" + capture))
-            routeStartsWithCif "/api/%s/" (fun capture -> text ("routeStartsWithCif:" + capture))
-            setStatusCode 404 >=> text "Not found"
+        GET |> choose [
+            empty |> routeStartsWithf "/API/%s/" (fun capture -> text ("routeStartsWithf:" + capture))
+            empty |> routeStartsWithCif "/api/%s/" (fun capture -> text ("routeStartsWithCif:" + capture))
+            SET_STATUS_CODE 404 |> text "Not found"
         ]
 
     let ctx = Substitute.For<HttpContext>()
@@ -387,13 +387,13 @@ let ``routeStartsWith(f|Cif)`` (uri:string, expected:string) =
 let ``routef: GET "/foo/%O/bar/%O" returns "Guid1: ..., Guid2: ..."`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route  "/"       >=> text "Hello World"
-            route  "/foo"    >=> text "bar"
-            routef "/foo/%s/bar" text
-            routef "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
-            routef "/foo/%O/bar/%O" (fun (guid1 : Guid, guid2 : Guid) -> text (sprintf "Guid1: %O, Guid2: %O" guid1 guid2))
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE  "/"       |> text "Hello World"
+            ROUTE  "/foo"    |> text "bar"
+            ROUTE_F "/foo/%s/bar" text
+            ROUTE_F "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
+            ROUTE_F "/foo/%O/bar/%O" (fun (guid1 : Guid, guid2 : Guid) -> text (sprintf "Guid1: %O, Guid2: %O" guid1 guid2))
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo/4ec87f064d1e41b49342ab1aead1f99d/bar/2a6c9185-95d9-4d8c-80a6-575f99c2a716")) |> ignore
@@ -412,13 +412,13 @@ let ``routef: GET "/foo/%O/bar/%O" returns "Guid1: ..., Guid2: ..."`` () =
 let ``routef: GET "/foo/%u/bar/%u" returns "Id1: ..., Id2: ..."`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route  "/"       >=> text "Hello World"
-            route  "/foo"    >=> text "bar"
-            routef "/foo/%s/bar" text
-            routef "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
-            routef "/foo/%u/bar/%u" (fun (id1 : uint64, id2 : uint64) -> text (sprintf "Id1: %u, Id2: %u" id1 id2))
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE  "/"       |> text "Hello World"
+            ROUTE  "/foo"    |> text "bar"
+            ROUTE_F "/foo/%s/bar" text
+            ROUTE_F "/foo/%s/%i" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
+            ROUTE_F "/foo/%u/bar/%u" (fun (id1 : uint64, id2 : uint64) -> text (sprintf "Id1: %u, Id2: %u" id1 id2))
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo/r1iKapqh_s4/bar/5aLu720NzTs")) |> ignore
@@ -437,9 +437,9 @@ let ``routef: GET "/foo/%u/bar/%u" returns "Id1: ..., Id2: ..."`` () =
 let ``routef: GET "/foo/bar/baz/qux" returns 404 "Not found"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            routef "/foo/%s/%s" (fun (s1, s2) -> text (sprintf "%s,%s" s1 s2))
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE_F "/foo/%s/%s" (fun (s1, s2) -> text (sprintf "%s,%s" s1 s2))
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/foo/bar/baz/qux")) |> ignore
@@ -466,13 +466,13 @@ let ``POST "/POsT/1" returns "1"`` () =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx (Newtonsoft None)
     let app =
-        choose [
-            GET >=> choose [
-                route "/" >=> text "Hello World" ]
-            POST >=> choose [
-                route    "/post/1" >=> text "2"
-                routeCif "/post/%i" json ]
-            setStatusCode 404 >=> text "Not found" ]
+        CHOOSE [
+            GET |> choose [
+                ROUTE "/" |> text "Hello World" ]
+            POST |> choose [
+                ROUTE   "/post/1" |> text "2"
+                ROUTE_CIF "/post/%i" json ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/POsT/1")) |> ignore
@@ -492,13 +492,13 @@ let ``POST "/POsT/523" returns "523"`` () =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx (Newtonsoft None)
     let app =
-        choose [
-            GET >=> choose [
-                route "/" >=> text "Hello World" ]
-            POST >=> choose [
-                route    "/post/1" >=> text "1"
-                routeCif "/post/%i" json ]
-            setStatusCode 404 >=> text "Not found" ]
+        CHOOSE [
+            GET |> choose [
+                ROUTE"/" |> text "Hello World" ]
+            POST |> choose [
+                ROUTE   "/post/1" |> text "1"
+                ROUTE_CIF "/post/%i" json ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Request.Method.ReturnsForAnyArgs "POST" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/POsT/523")) |> ignore
@@ -534,10 +534,10 @@ type Purchase = { PaymentMethod : PaymentMethod }
 let ``routeBind: Route has matching union type``() =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            routeBind<Purchase> "/{paymentMethod}"
+        GET |> choose [
+            empty |> routeBind<Purchase> "/{paymentMethod}"
                 (fun p -> sprintf "%s" (p.PaymentMethod.ToString()) |> text)
-            setStatusCode 404 >=> text "Not found" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/credit")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -554,10 +554,10 @@ let ``routeBind: Route has matching union type``() =
 let ``routeBind: Route doesn't match union type``() =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            routeBind<Purchase> "/{paymentMethod}"
+        GET |> choose [
+            empty |> routeBind<Purchase> "/{paymentMethod}"
                 (fun p -> sprintf "%s" (p.PaymentMethod.ToString()) |> text)
-            setStatusCode 404 >=> text "Not found" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/wrong")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -573,7 +573,7 @@ let ``routeBind: Route doesn't match union type``() =
 [<Fact>]
 let ``routeBind: Normal route``() =
     let ctx = Substitute.For<HttpContext>()
-    let app = GET >=> routeBind<RouteBind> "/{foo}/{bar}/{id}" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
+    let app = GET |> routeBind<RouteBind> "/{foo}/{bar}/{id}" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/Hello/1/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -590,7 +590,7 @@ let ``routeBind: Normal route``() =
 [<Fact>]
 let ``routeBind: Normal route with trailing slash``() =
     let ctx = Substitute.For<HttpContext>()
-    let app = GET >=> routeBind<RouteBind> "/{foo}/{bar}/{id}/" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
+    let app = GET |> routeBind<RouteBind> "/{foo}/{bar}/{id}/" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/Hello/1/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d/")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -607,7 +607,7 @@ let ``routeBind: Normal route with trailing slash``() =
 [<Fact>]
 let ``routeBind: Route with (/*) matches mutliple trailing slashes``() =
     let ctx = Substitute.For<HttpContext>()
-    let app = GET >=> routeBind<RouteBind> "/{foo}/{bar}/{id}(/*)" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
+    let app = GET |> routeBind<RouteBind> "/{foo}/{bar}/{id}(/*)" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/Hello/1/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d///")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -624,7 +624,7 @@ let ``routeBind: Route with (/*) matches mutliple trailing slashes``() =
 [<Fact>]
 let ``routeBind: Route with (/*) matches no trailing slash``() =
     let ctx = Substitute.For<HttpContext>()
-    let app = GET >=> routeBind<RouteBind> "/{foo}/{bar}/{id}(/*)" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
+    let app = GET |> routeBind<RouteBind> "/{foo}/{bar}/{id}(/*)" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/Hello/2/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -641,7 +641,7 @@ let ``routeBind: Route with (/*) matches no trailing slash``() =
 [<Fact>]
 let ``routeBind: Route with (/?) matches single trailing slash``() =
     let ctx = Substitute.For<HttpContext>()
-    let app = GET >=> routeBind<RouteBind> "/{foo}/{bar}/{id}(/?)" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
+    let app = GET |> routeBind<RouteBind> "/{foo}/{bar}/{id}(/?)" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/Hello/3/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d/")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -658,7 +658,7 @@ let ``routeBind: Route with (/?) matches single trailing slash``() =
 [<Fact>]
 let ``routeBind: Route with (/?) matches no trailing slash``() =
     let ctx = Substitute.For<HttpContext>()
-    let app = GET >=> routeBind<RouteBind> "/{foo}/{bar}/{id}(/?)" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
+    let app = GET |> routeBind<RouteBind> "/{foo}/{bar}/{id}(/?)" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/Hello/4/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -675,7 +675,7 @@ let ``routeBind: Route with (/?) matches no trailing slash``() =
 [<Fact>]
 let ``routeBind: Route with non parameterised part``() =
     let ctx = Substitute.For<HttpContext>()
-    let app = GET >=> routeBind<RouteBind> "/api/{foo}/{bar}/{id}" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
+    let app = GET |> routeBind<RouteBind> "/api/{foo}/{bar}/{id}" (fun m -> sprintf "%s %i %O" m.Foo m.Bar m.Id |> text)
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/api/Hello/1/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -692,7 +692,7 @@ let ``routeBind: Route with non parameterised part``() =
 [<Fact>]
 let ``routeBind: Route with non parameterised part and with Guid binding``() =
     let ctx = Substitute.For<HttpContext>()
-    let app = GET >=> routeBind<RouteBindId> "/api/{id}" (fun m -> sprintf "%O" m.Id |> text)
+    let app = GET |> routeBind<RouteBindId> "/api/{id}" (fun m -> sprintf "%O" m.Id |> text)
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/api/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -709,7 +709,7 @@ let ``routeBind: Route with non parameterised part and with Guid binding``() =
 [<Fact>]
 let ``routeBind: Route with non parameterised part and with (/?)``() =
     let ctx = Substitute.For<HttpContext>()
-    let app = GET >=> routeBind<RouteBindId> "/api/{id}(/?)" (fun m -> sprintf "%O" m.Id |> text)
+    let app = GET |> routeBind<RouteBindId> "/api/{id}(/?)" (fun m -> sprintf "%O" m.Id |> text)
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/api/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d/")) |> ignore
     ctx.Response.Body <- new MemoryStream()
@@ -726,7 +726,7 @@ let ``routeBind: Route with non parameterised part and with (/?)``() =
 [<Fact>]
 let ``routeBind: Route nested after subRoute``() =
     let ctx = Substitute.For<HttpContext>()
-    let app = GET >=> subRoute "/test" (routeBind<RouteBindId> "/api/{id}(/?)" (fun m -> sprintf "%O" m.Id |> text))
+    let app = GET |> (subRoute "/test" (empty |> routeBind<RouteBindId> "/api/{id}(/?)" (fun m -> sprintf "%O" m.Id |> text)))
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
     ctx.Request.Path.ReturnsForAnyArgs (PathString("/test/api/f40580b1-d55b-4fe2-b6fb-ca4f90749a9d/")) |> ignore
@@ -749,16 +749,16 @@ let ``routeBind: Route nested after subRoute``() =
 let ``subRoute: Route with empty route`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route "/"    >=> text "Hello World"
-            route "/foo" >=> text "bar"
-            subRoute "/api" (
-                choose [
-                    route ""       >=> text "api root"
-                    route "/admin" >=> text "admin"
-                    route "/users" >=> text "users" ] )
-            route "/api/test" >=> text "test"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE "/"    |> text "Hello World"
+            ROUTE "/foo" |> text "bar"
+            SUB_ROUTE "/api" (
+                CHOOSE [
+                    ROUTE ""       |> text "api root"
+                    ROUTE "/admin" |> text "admin"
+                    ROUTE "/users" |> text "users" ] )
+            ROUTE "/api/test" |> text "test"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -778,16 +778,16 @@ let ``subRoute: Route with empty route`` () =
 let ``subRoute: Normal nested route after subRoute`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route "/"    >=> text "Hello World"
-            route "/foo" >=> text "bar"
-            subRoute "/api" (
-                choose [
-                    route ""       >=> text "api root"
-                    route "/admin" >=> text "admin"
-                    route "/users" >=> text "users" ] )
-            route "/api/test" >=> text "test"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE "/"    |> text "Hello World"
+            ROUTE "/foo" |> text "bar"
+            SUB_ROUTE "/api" (
+                CHOOSE [
+                    ROUTE ""       |> text "api root"
+                    ROUTE "/admin" |> text "admin"
+                    ROUTE "/users" |> text "users" ] )
+            ROUTE "/api/test" |> text "test"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -810,16 +810,16 @@ let ``subRoute: Route after subRoute has same beginning of path`` () =
         let ctx = Substitute.For<HttpContext>()
 
         let app =
-            GET >=> choose [
-                route "/"    >=> text "Hello World"
-                route "/foo" >=> text "bar"
-                subRoute "/api" (
-                    choose [
-                        route ""       >=> text "api root"
-                        route "/admin" >=> text "admin"
-                        route "/users" >=> text "users" ] )
-                route "/api/test" >=> text "test"
-                setStatusCode 404 >=> text "Not found" ]
+            GET |> choose [
+                ROUTE "/"    |> text "Hello World"
+                ROUTE "/foo" |> text "bar"
+                SUB_ROUTE "/api" (
+                    CHOOSE [
+                        ROUTE ""       |> text "api root"
+                        ROUTE "/admin" |> text "admin"
+                        ROUTE "/users" |> text "users" ] )
+                ROUTE "/api/test" |> text "test"
+                SET_STATUS_CODE 404 |> text "Not found" ]
 
         ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
         ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -838,25 +838,25 @@ let ``subRoute: Route after subRoute has same beginning of path`` () =
 let ``subRoute: Nested sub routes`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route "/"    >=> text "Hello World"
-            route "/foo" >=> text "bar"
-            subRoute "/api" (
-                choose [
-                    route ""       >=> text "api root"
-                    route "/admin" >=> text "admin"
-                    route "/users" >=> text "users"
-                    subRoute "/v2" (
-                        choose [
-                            route ""       >=> text "api root v2"
-                            route "/admin" >=> text "admin v2"
-                            route "/users" >=> text "users v2"
+        GET |> choose [
+            ROUTE "/"    |> text "Hello World"
+            ROUTE "/foo" |> text "bar"
+            SUB_ROUTE "/api" (
+                CHOOSE [
+                    ROUTE ""       |> text "api root"
+                    ROUTE "/admin" |> text "admin"
+                    ROUTE "/users" |> text "users"
+                    SUB_ROUTE "/v2" (
+                        CHOOSE [
+                            ROUTE ""       |> text "api root v2"
+                            ROUTE "/admin" |> text "admin v2"
+                            ROUTE "/users" |> text "users v2"
                         ]
                     )
                 ]
             )
-            route "/api/test" >=> text "test"
-            setStatusCode 404 >=> text "Not found" ]
+            ROUTE "/api/test" |> text "test"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -876,26 +876,26 @@ let ``subRoute: Nested sub routes`` () =
 let ``subRoute: Multiple nested sub routes`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route "/"    >=> text "Hello World"
-            route "/foo" >=> text "bar"
-            subRoute "/api" (
-                choose [
-                    route "/users" >=> text "users"
-                    subRoute "/v2" (
-                        choose [
-                            route "/admin" >=> text "admin v2"
-                            route "/users" >=> text "users v2"
+        GET |> choose [
+            ROUTE "/"    |> text "Hello World"
+            ROUTE "/foo" |> text "bar"
+            SUB_ROUTE "/api" (
+                CHOOSE [
+                    ROUTE "/users" |> text "users"
+                    SUB_ROUTE "/v2" (
+                        CHOOSE [
+                            ROUTE "/admin" |> text "admin v2"
+                            ROUTE "/users" |> text "users v2"
                         ]
                     )
-                    subRoute "/v2" (
-                        route "/admin2" >=> text "correct admin2"
+                    SUB_ROUTE "/v2" (
+                        ROUTE "/admin2" |> text "correct admin2"
                     )
                 ]
             )
-            route "/api/test"   >=> text "test"
-            route "/api/v2/else" >=> text "else"
-            setStatusCode 404 >=> text "Not found" ]
+            ROUTE "/api/test"   |> text "test"
+            ROUTE "/api/v2/else" |> text "else"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -915,27 +915,27 @@ let ``subRoute: Multiple nested sub routes`` () =
 let ``subRoute: Route after nested sub routes has same beginning of path`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route "/"    >=> text "Hello World"
-            route "/foo" >=> text "bar"
-            subRoute "/api" (
-                choose [
-                    route ""       >=> text "api root"
-                    route "/admin" >=> text "admin"
-                    route "/users" >=> text "users"
-                    subRoute "/v2" (
-                        choose [
-                            route ""       >=> text "api root v2"
-                            route "/admin" >=> text "admin v2"
-                            route "/users" >=> text "users v2"
+        GET |> choose [
+            ROUTE "/"    |> text "Hello World"
+            ROUTE "/foo" |> text "bar"
+            SUB_ROUTE "/api" (
+                CHOOSE [
+                    ROUTE ""       |> text "api root"
+                    ROUTE "/admin" |> text "admin"
+                    ROUTE "/users" |> text "users"
+                    SUB_ROUTE "/v2" (
+                        CHOOSE [
+                            ROUTE ""       |> text "api root v2"
+                            ROUTE "/admin" |> text "admin v2"
+                            ROUTE "/users" |> text "users v2"
                         ]
                     )
-                    route "/yada" >=> text "yada"
+                    ROUTE "/yada" |> text "yada"
                 ]
             )
-            route "/api/test"   >=> text "test"
-            route "/api/v2/else" >=> text "else"
-            setStatusCode 404 >=> text "Not found" ]
+            ROUTE "/api/test"   |> text "test"
+            ROUTE "/api/v2/else" |> text "else"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -955,15 +955,15 @@ let ``subRoute: Route after nested sub routes has same beginning of path`` () =
 let ``subRoute: routef inside subRoute`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            route "/"    >=> text "Hello World"
-            route "/foo" >=> text "bar"
-            subRoute "/api" (
-                choose [
-                    route  "" >=> text "api root"
-                    routef "/foo/bar/%s" text ] )
-            route "/api/test" >=> text "test"
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            ROUTE "/"    |> text "Hello World"
+            ROUTE "/foo" |> text "bar"
+            SUB_ROUTE "/api" (
+                CHOOSE [
+                    ROUTE  "" |> text "api root"
+                    ROUTE_F "/foo/bar/%s" text ] )
+            ROUTE "/api/test" |> text "test"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -986,11 +986,12 @@ let ``subRoute: routef inside subRoute`` () =
 [<Fact>]
 let ``routef: Validation`` () =
     Assert.Throws( fun () ->
-        GET >=> choose [
-            route   "/"       >=> text "Hello World"
-            route   "/foo"    >=> text "bar"
-            routef "/foo/%s/%d" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
-            setStatusCode 404 >=> text "Not found" ]
+        let app =GET |> choose [
+            ROUTE   "/"       |> text "Hello World"
+            ROUTE   "/foo"    |> text "bar"
+            ROUTE_F "/foo/%s/%d" (fun (name, age) -> text (sprintf "Name: %s, Age: %d" name age))
+            SET_STATUS_CODE 404 |> text "Not found" ]
+        app next
         |> ignore
     ) |> ignore
 
@@ -998,14 +999,14 @@ let ``routef: Validation`` () =
 let ``subRoutef: GET "/" returns "Not found"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            subRoutef "/%s/%i" (fun (lang, version) ->
-                choose [
-                    route  "/foo" >=> text "bar"
-                    routef "/%s" (fun name -> text (sprintf "Hello %s! Lang: %s, Version: %i" name lang version))
+        GET |> choose [
+            empty |> subRoutef "/%s/%i" (fun (lang, version) ->
+                CHOOSE [
+                    ROUTE  "/foo" |> text "bar"
+                    ROUTE_F "/%s" (fun name -> text (sprintf "Hello %s! Lang: %s, Version: %i" name lang version))
                 ])
-            route "/bar" >=> text "foo"
-            setStatusCode 404 >=> text "Not found" ]
+            ROUTE "/bar" |> text "foo"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -1025,14 +1026,14 @@ let ``subRoutef: GET "/" returns "Not found"`` () =
 let ``subRoutef: GET "/bar" returns "foo"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            subRoutef "/%s/%i" (fun (lang, version) ->
-                choose [
-                    route  "/foo" >=> text "bar"
-                    routef "/%s" (fun name -> text (sprintf "Hello %s! Lang: %s, Version: %i" name lang version))
+        GET |> choose [
+            empty |> subRoutef "/%s/%i" (fun (lang, version) ->
+                CHOOSE [
+                    ROUTE  "/foo" |> text "bar"
+                    ROUTE_F "/%s" (fun name -> text (sprintf "Hello %s! Lang: %s, Version: %i" name lang version))
                 ])
-            route "/bar" >=> text "foo"
-            setStatusCode 404 >=> text "Not found" ]
+            ROUTE "/bar" |> text "foo"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -1052,14 +1053,14 @@ let ``subRoutef: GET "/bar" returns "foo"`` () =
 let ``subRoutef: GET "/John/5/foo" returns "bar"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            subRoutef "/%s/%i" (fun (lang, version) ->
-                choose [
-                    route  "/foo" >=> text "bar"
-                    routef "/%s" (fun name -> text (sprintf "Hello %s! Lang: %s, Version: %i" name lang version))
+        GET |> choose [
+            empty |> subRoutef "/%s/%i" (fun (lang, version) ->
+                CHOOSE [
+                    ROUTE  "/foo" |> text "bar"
+                    ROUTE_F "/%s" (fun name -> text (sprintf "Hello %s! Lang: %s, Version: %i" name lang version))
                 ])
-            route "/bar" >=> text "foo"
-            setStatusCode 404 >=> text "Not found" ]
+            ROUTE "/bar" |> text "foo"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -1079,14 +1080,14 @@ let ``subRoutef: GET "/John/5/foo" returns "bar"`` () =
 let ``subRoutef: GET "/en/10/Julia" returns "Hello Julia! Lang: en, Version: 10"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            subRoutef "/%s/%i" (fun (lang, version) ->
-                choose [
-                    route  "/foo" >=> text "bar"
-                    routef "/%s" (fun name -> text (sprintf "Hello %s! Lang: %s, Version: %i" name lang version))
+        GET |> choose [
+            empty |> subRoutef "/%s/%i" (fun (lang, version) ->
+                CHOOSE [
+                    ROUTE  "/foo" |> text "bar"
+                    ROUTE_F "/%s" (fun name -> text (sprintf "Hello %s! Lang: %s, Version: %i" name lang version))
                 ])
-            route "/bar" >=> text "foo"
-            setStatusCode 404 >=> text "Not found" ]
+            ROUTE "/bar" |> text "foo"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -1106,14 +1107,14 @@ let ``subRoutef: GET "/en/10/Julia" returns "Hello Julia! Lang: en, Version: 10"
 let ``subRoutef: GET "/en/10/api/Julia" returns "Hello Julia! Lang: en, Version: 10"`` () =
     let ctx = Substitute.For<HttpContext>()
     let app =
-        GET >=> choose [
-            subRoutef "/%s/%i/api" (fun (lang, version) ->
-                choose [
-                    route  "/foo" >=> text "bar"
-                    routef "/%s" (fun name -> text (sprintf "Hello %s! Lang: %s, Version: %i" name lang version))
+        GET |> choose [
+            empty |> subRoutef "/%s/%i/api" (fun (lang, version) ->
+                CHOOSE [
+                    ROUTE  "/foo" |> text "bar"
+                    ROUTE_F "/%s" (fun name -> text (sprintf "Hello %s! Lang: %s, Version: %i" name lang version))
                 ])
-            route "/bar" >=> text "foo"
-            setStatusCode 404 >=> text "Not found" ]
+            ROUTE "/bar" |> text "foo"
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -1138,9 +1139,9 @@ let ``subRouteCi: Non-filtering handler after subRouteCi is called`` () =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx (Newtonsoft None)
     let app =
-        GET >=> choose [
-            subRouteCi "/foo" (text "subroute /foo")
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            SUB_ROUTE_CI "/foo" (TEXT "subroute /foo")
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -1161,10 +1162,10 @@ let ``subRouteCi: Nested route after subRouteCi is called`` () =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx (Newtonsoft None)
     let app =
-        GET >=> choose [
-            subRouteCi "/foo" (
-                route "/bar" >=> text "subroute /foo/bar")
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            SUB_ROUTE_CI "/foo" (
+                ROUTE "/bar" |> text "subroute /foo/bar")
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -1185,13 +1186,13 @@ let ``subRouteCi: Nested route after subRouteCi is still case sensitive`` () =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx (Newtonsoft None)
     let app =
-        GET >=> choose [
-            subRouteCi "/foo" (
-                choose [
-                    route "/bar" >=> text "subroute /foo/bar"
-                    setStatusCode 404 >=> text "Not found - nested"
+        GET |> choose [
+            SUB_ROUTE_CI "/foo" (
+                CHOOSE [
+                    ROUTE "/bar" |> text "subroute /foo/bar"
+                    SET_STATUS_CODE 404 |> text "Not found - nested"
                 ])
-            setStatusCode 404 >=> text "Not found" ]
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore
@@ -1212,10 +1213,10 @@ let ``subRouteCi: Nested routeCi after subRouteCi is called`` () =
     let ctx = Substitute.For<HttpContext>()
     mockJson ctx (Newtonsoft None)
     let app =
-        GET >=> choose [
-            subRouteCi "/foo" (
-                routeCi "/bar" >=> text "subroute /foo/bar")
-            setStatusCode 404 >=> text "Not found" ]
+        GET |> choose [
+            SUB_ROUTE_CI "/foo" (
+                ROUTE_CI "/bar" |> text "subroute /foo/bar")
+            SET_STATUS_CODE 404 |> text "Not found" ]
 
     ctx.Items.Returns (new Dictionary<obj,obj>() :> IDictionary<obj,obj>) |> ignore
     ctx.Request.Method.ReturnsForAnyArgs "GET" |> ignore

--- a/tests/Giraffe.Tests/StreamingTests.fs
+++ b/tests/Giraffe.Tests/StreamingTests.fs
@@ -48,23 +48,23 @@ module Urls =
     let rangeProcessingDisabled = "/range-processing-disabled"
 
 module WebApp =
-    let streamHandler (enableRangeProcessing : bool) : HttpHandler =
-        streamFile enableRangeProcessing "streaming.txt" None None
+    let streamHandler (enableRangeProcessing : bool) source : HttpHandler =
+        streamFile enableRangeProcessing "streaming.txt" None None source
 
     let webApp =
-        choose [
-            route Urls.rangeProcessingEnabled  >=> streamHandler true
-            route Urls.rangeProcessingDisabled >=> streamHandler false
+        CHOOSE [
+            ROUTE Urls.rangeProcessingEnabled  |> streamHandler true
+            ROUTE Urls.rangeProcessingDisabled |> streamHandler false
         ]
 
-    let errorHandler (ex : Exception) (_ : ILogger) : HttpHandler =
+    let errorHandler (ex : Exception) (_ : ILogger) : HttpHandler -> HttpHandler =
         printfn "Error: %s" ex.Message
         printfn "StackTrace:%s %s" Environment.NewLine ex.StackTrace
-        setStatusCode 500 >=> text ex.Message
+        setStatusCode 500 >> text ex.Message
 
     let configureApp _ (app : IApplicationBuilder) =
         app.UseGiraffeErrorHandler(errorHandler)
-           .UseGiraffe webApp
+           .UseGiraffe (webApp)
 
     let configureServices (services : IServiceCollection) =
         services.AddGiraffe() |> ignore


### PR DESCRIPTION
Remove Kleisli composition (`>=>`)  in favor of normal functional composition (`>>`). This will enable us to also use normal F# pipelining to create web-apps.